### PR TITLE
githubから警告が出ていたloofahとrackのgemをbundle updateした

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.1)
@@ -112,7 +112,7 @@ GEM
       pry (>= 0.10.4)
     public_suffix (3.0.3)
     puma (3.12.0)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.1.6)
@@ -223,4 +223,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.16.3
+   1.17.1


### PR DESCRIPTION
## やったこと
- gemの `loofah` と `rack` の脆弱性に関する警告が出ていたので、 
`bundle update loofah` と `bundle update rack` を実行した
![2018-11-16 11 03 21](https://user-images.githubusercontent.com/27620649/48593238-4b6f9880-e98f-11e8-91e9-fa4a2a109e54.png)

![2018-11-16 11 03 32](https://user-images.githubusercontent.com/27620649/48593245-50cce300-e98f-11e8-8af9-2e3a77f06de5.png)
