### PR TITLE
Rails5.2にアップデートして不要になったCSRFの記述を削除

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,2 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery with: :exception
 end


### PR DESCRIPTION
## 概要
Rails5.2ではCSRFのチェックがコールバックにデフォルトで組み込まれるようになったので、
Application_controller.rbに明示的に記載する必要がなくなったので削除する。

## 参考リンク
https://railsguides.jp/upgrading_ruby_on_rails.html#protect-from-forgery%E3%81%AF%E4%BB%8A%E5%BE%8C%E3%83%87%E3%83%95%E3%82%A9%E3%83%AB%E3%83%88%E3%81%A7prepend-false%E3%81%AB%E8%A8%AD%E5%AE%9A%E3%81%95%E3%82%8C%E3%82%8B