### PR TITLE
フォームにデバッグ表示用の要素が混在していたので削除した

### DIFF
--- a/app/javascript/new_item.vue
+++ b/app/javascript/new_item.vue
@@ -22,8 +22,6 @@
         <button @click="add" v-bind:disabled="clicked" class="nes-btn is-primary">Add</button>
       </form>
       <br>
-      <p>Debug</p>
-      <pre>{{ $data }}</pre>
     </div>
 
     <dialog class="nes-dialog" id="dialog-default">


### PR DESCRIPTION
## 概要
フォームにデバッグ用の値の表示がされてしまっていたので表示しないように修正した。

## Before
<img width="865" alt="スクリーンショット 2019-08-08 1 06 16" src="https://user-images.githubusercontent.com/27620649/62638599-c131ef00-b978-11e9-8364-a53e0c0546a6.png">

## After
<img width="858" alt="スクリーンショット 2019-08-08 1 02 06" src="https://user-images.githubusercontent.com/27620649/62638410-5da7c180-b978-11e9-8069-886fc1849ede.png">
