### PR TITLE
RSpecがCI上で動かない設定になっていたので修正した

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - checkout
       - run: gem install bundler -v 1.17.2
-      - run: bundle install --path vendor/bundle
+      - run: bundle install
       - persist_to_workspace:
           root: ~/shoukaigame_app
           paths:
@@ -38,7 +38,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            bundle install --jobs=4 --retry=3 --path vendor/bundle
+            bundle install --jobs=4 --retry=3
       - run:
           name: Run Rubocop
           command: bundle exec rubocop --parallel
@@ -50,7 +50,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            bundle install --jobs=4 --retry=3 --path vendor/bundle
+            bundle install --jobs=4 --retry=3
       # Database setup
       - run:
           name: Database setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,10 @@
 #
 version: 2
 defaults: &defaults
+  working_directory: ~/shoukaigame_app
   docker:
     # specify the version you desire here
-    - image: ruby:2.6.3
+    - image: circleci/ruby:2.6.3-node-browsers-legacy
       environment:
         RAILS_ENV: test
         TZ: /usr/share/zoneinfo/Asia/Tokyo
@@ -14,23 +15,16 @@ defaults: &defaults
         BUNDLER_VERSION: 1.17.2
     - image: postgres:11.1-alpine
       environment:
-        - POSTGRES_USER: vimmer
-        - POSTGRES_PASSWORD: shoukaigame
+        - POSTGRES_USER: postgres
+        - POSTGRES_PASSWORD: shoukaigame_password
         - PGDATA: /dev/shm/pgdata/data
-  working_directory: ~/shoukaigame_app
 jobs:
   build:
     <<: *defaults
     steps:
       - checkout
-      - restore_cache:
-          key: shoukaigame-app-gemfile-{{ checksum "Gemfile.lock" }}
       - run: gem install bundler -v 1.17.2
-      - run: bundle install
-      - save_cache:
-          key: shoukaigame-app-gemfile-{{ checksum "Gemfile.lock" }}
-          paths:
-            - vendor/bundle
+      - run: bundle install --path vendor/bundle
       - persist_to_workspace:
           root: ~/shoukaigame_app
           paths:
@@ -42,6 +36,10 @@ jobs:
       - attach_workspace:
           at: ~/shoukaigame_app
       - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+      - run:
           name: Run Rubocop
           command: bundle exec rubocop --parallel
   rspec:
@@ -49,6 +47,17 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/shoukaigame_app
+      - run:
+          name: install dependencies
+          command: |
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+      # Database setup
+      - run:
+          name: Database setup
+          command: |
+            bundle exec rake db:drop
+            bundle exec rake db:create RAILS_ENV=test
+            bundle exec rake db:schema:load RAILS_ENV=test
       - run:
           name: Run RSpec
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,6 @@ jobs:
       - run:
           name: Database setup
           command: |
-            bundle exec rake db:drop
             bundle exec rake db:create RAILS_ENV=test
             bundle exec rake db:schema:load RAILS_ENV=test
       - run:

--- a/config/database.yml
+++ b/config/database.yml
@@ -60,6 +60,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
+  host: localhost
   database: shoukaiGame_test
 
 # As with config/secrets.yml, you never want to store sensitive information,


### PR DESCRIPTION
## やったこと
- database.ymlのテスト環境のhost指定が漏れていたのでlocalhostを追加
  - host指定がないためCI上のrails db:createなどでdbが読み込まれずバグっていた模様 🔥 
- .circleci/config.ymlの記載見直し
  - node含むRubyのDockerイメージを指定(nodeを含まない場合は別途nodeを入れる必要があるので今回はnodeと一緒に入れられる便利なイメージを選択する)
  - rails db:createなどの必要な準備系コマンドの記載漏れを追加

## FIXしたバグ概要
- CircleCI上でRSpecの実行環境を作る際のbundle exec rails db:createで `PG::ConnectionBad: could not traslate host name "db" to address: Name or service not known` が発生していた
→database.ymlのtest環境のhostをlocalhostに指定して対応
- `ExecJS::RuntimeUnavailable:
  Could not find a JavaScript runtime. See https://github.com/rails/execjs for a list of available runtimes.`
→nodeを含まないRubyのイメージを指定していたせいでCircleCI上でnodeが無いことによるエラーが発生していたので、nodeを含むRubyのDockerイメージを指定することで対応