### PR TITLE
全件からランダムに1件レコードを取得するメソッドの改善

### DIFF
--- a/app/controllers/conjunctions_controller.rb
+++ b/app/controllers/conjunctions_controller.rb
@@ -5,7 +5,7 @@ class ConjunctionsController < ApplicationController
   end
 
   def result
-    @conjunction = Conjunction.pick_up_at_random
+    @conjunction = Conjunction.pluck_a_record_from_all_or_offset
     render :result
   end
 

--- a/app/controllers/conjunctions_controller.rb
+++ b/app/controllers/conjunctions_controller.rb
@@ -5,7 +5,7 @@ class ConjunctionsController < ApplicationController
   end
 
   def result
-    @conjunction = Conjunction.pluck_a_record_from_all_or_offset
+    @conjunction = Conjunction.pluck_a_theme_from_all_or_offset
     render :result
   end
 

--- a/app/controllers/conjunctions_controller.rb
+++ b/app/controllers/conjunctions_controller.rb
@@ -5,7 +5,7 @@ class ConjunctionsController < ApplicationController
   end
 
   def result
-    @conjunction = Conjunction.select_a_word_at_random
+    @conjunction = Conjunction.pick_up_at_random
     render :result
   end
 

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -5,7 +5,7 @@ class QuestionsController < ApplicationController
   end
 
   def result
-    @question = Question.pick_up_at_random
+    @question = Question.pluck_a_record_from_all_or_offset
     render :result
   end
 

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -5,7 +5,7 @@ class QuestionsController < ApplicationController
   end
 
   def result
-    @question = Question.select_a_word_at_random
+    @question = Question.pick_up_at_random
     render :result
   end
 

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -5,7 +5,7 @@ class QuestionsController < ApplicationController
   end
 
   def result
-    @question = Question.pluck_a_record_from_all_or_offset
+    @question = Question.pluck_a_theme_from_all_or_offset
     render :result
   end
 

--- a/app/controllers/themes_controller.rb
+++ b/app/controllers/themes_controller.rb
@@ -5,7 +5,7 @@ class ThemesController < ApplicationController
   end
 
   def result
-    @theme = Theme.pluck_a_record_from_all_or_offset
+    @theme = Theme.pluck_a_theme_from_all_or_offset
     render :result
   end
 

--- a/app/controllers/themes_controller.rb
+++ b/app/controllers/themes_controller.rb
@@ -5,7 +5,7 @@ class ThemesController < ApplicationController
   end
 
   def result
-    @theme = Theme.select_a_word_at_random
+    @theme = Theme.pick_up_at_random
     render :result
   end
 

--- a/app/controllers/themes_controller.rb
+++ b/app/controllers/themes_controller.rb
@@ -5,7 +5,7 @@ class ThemesController < ApplicationController
   end
 
   def result
-    @theme = Theme.pick_up_at_random
+    @theme = Theme.pluck_a_record_from_all_or_offset
     render :result
   end
 

--- a/app/models/concerns/select_a_word_at_random.rb
+++ b/app/models/concerns/select_a_word_at_random.rb
@@ -1,20 +1,17 @@
 module SelectAWordAtRandom
   extend ActiveSupport::Concern
 
-  def increment_impressions
-    update(impressions: impressions + 1)
-  end
-
   module ClassMethods
-    def select_a_word_at_random
-      record = all.sample_other_than_latest
-      record.increment_impressions
-
-      record
+    OFFSET = 1
+    def pick_up_at_random(default = 0)
+      binding.pry
+      offset(rand(self.count - default)).first
     end
 
     def sample_other_than_latest
-      count > 1 ? first(count - 1).sample : sample
+      return pick_up_at_random if count.zero?
+
+      pick_up_at_random(OFFSET)
     end
   end
 end

--- a/app/models/concerns/select_a_word_at_random.rb
+++ b/app/models/concerns/select_a_word_at_random.rb
@@ -4,11 +4,10 @@ module SelectAWordAtRandom
   module ClassMethods
     OFFSET = 1
     def pick_up_at_random(default = 0)
-      binding.pry
       offset(rand(self.count - default)).first
     end
 
-    def sample_other_than_latest
+    def pluck_a_record_from_all_or_offset
       return pick_up_at_random if count.zero?
 
       pick_up_at_random(OFFSET)

--- a/app/models/concerns/select_a_word_at_random.rb
+++ b/app/models/concerns/select_a_word_at_random.rb
@@ -4,7 +4,7 @@ module SelectAWordAtRandom
   module ClassMethods
     OFFSET = 1
     def pick_up_at_random(default = 0)
-      offset(rand(self.count - default)).first
+      offset(rand(count - default)).first
     end
 
     def pluck_a_record_from_all_or_offset

--- a/app/models/concerns/theme_selector.rb
+++ b/app/models/concerns/theme_selector.rb
@@ -1,4 +1,4 @@
-module SelectAWordAtRandom
+module ThemeSelector
   extend ActiveSupport::Concern
 
   module ClassMethods

--- a/app/models/concerns/theme_selector.rb
+++ b/app/models/concerns/theme_selector.rb
@@ -7,7 +7,7 @@ module ThemeSelector
       offset(rand(count - default)).first
     end
 
-    def pluck_a_record_from_all_or_offset
+    def pluck_a_theme_from_all_or_offset
       return pick_up_at_random if count.zero?
 
       pick_up_at_random(OFFSET)

--- a/app/models/conjunction.rb
+++ b/app/models/conjunction.rb
@@ -1,3 +1,3 @@
 class Conjunction < ApplicationRecord
-  include SelectAWordAtRandom
+  include ThemeSelector
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,5 +1,5 @@
 class Question < ApplicationRecord
-  include SelectAWordAtRandom
+  include ThemeSelector
 
   enum category: { conjunction: 0, question: 1, theme: 2, programming: 3 }
 

--- a/app/models/theme.rb
+++ b/app/models/theme.rb
@@ -1,3 +1,3 @@
 class Theme < ApplicationRecord
-  include SelectAWordAtRandom
+  include ThemeSelector
 end


### PR DESCRIPTION
## BEFORE
- 過去には使われていたが、現在は使われていないロジックがある
    - `impressions`への加算
- データの取得が全てのデータを取得したのち一件を取得しており、メモリを食う書き方になっている(Model.all.sample)

## AFTER
- 使われていないロジックを削除した
- randメソッドで全体のレコード数以下をランダムで生成し、その数で相殺するよう変更しました
    - 速度は測定していませんが、探索件数が減っているので早くなっている…はず